### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,11 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-mplex.git", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-noise.git", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
+
+        // Test Dependencies
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-mplex.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-noise.git", .upToNextMinor(from: "0.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/LibP2PIdentify/LibP2PIdentify.swift
+++ b/Sources/LibP2PIdentify/LibP2PIdentify.swift
@@ -390,7 +390,7 @@ extension Identify {
     // - TODO:  This doesn't handle multiple parallel outbound pings to the same peer
     func initiateOutboundPingTo(addr: Multiaddr) -> EventLoopFuture<TimeAmount> {
         el.flatSubmit {
-            guard let cid = addr.getPeerID(), let peer = try? PeerID(cid: cid) else {
+            guard let peer = try? addr.getPeerID() else {
                 self.logger.warning("Identify::Failed to ping addr `\(addr)`. A valid peerID is neccessary")
                 return self.el.makeFailedFuture(Errors.timedOut)
             }
@@ -427,7 +427,7 @@ extension Identify {
         let startTime = DispatchTime.now().uptimeNanoseconds
         /// Check to see if this ping was initiated by our IndetifyManager...
         el.execute {
-            if let initiatedPing = self.pingCache.removeValue(forKey: remotePeer.bytes) {
+            if let initiatedPing = self.pingCache.removeValue(forKey: remotePeer.id) {
                 self.pingCache[bytes] = PendingPing(
                     peer: remotePeer.b58String,
                     startTime: startTime,

--- a/Sources/LibP2PIdentify/LibP2PIdentify.swift
+++ b/Sources/LibP2PIdentify/LibP2PIdentify.swift
@@ -364,7 +364,7 @@ extension Identify {
     // - TODO:  This doesn't handle multiple parallel outbound pings to the same peer
     func initiateOutboundPingTo(peer: PeerID) -> EventLoopFuture<TimeAmount> {
         el.flatSubmit {
-            if let outstandingPing = self.pingCache[peer.bytes] {
+            if let outstandingPing = self.pingCache[peer.id] {
                 // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
                 if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
                     print("We have an outstanding ping thats older than 3 seconds")
@@ -373,11 +373,11 @@ extension Identify {
                     // If the outstanding ping hasn't timed out yet, just return the results of the existing promise
                     return promise.futureResult
                 }
-                self.pingCache.removeValue(forKey: peer.bytes)
+                self.pingCache.removeValue(forKey: peer.id)
             }
             //guard self.pingCache[peer.bytes] == nil else { return application!.eventLoopGroup.next().makeFailedFuture(Errors.timedOut) }
             let promise = self.application!.eventLoopGroup.next().makePromise(of: TimeAmount.self)
-            self.pingCache[peer.bytes] = PendingPing(
+            self.pingCache[peer.id] = PendingPing(
                 peer: "",
                 startTime: DispatchTime.now().uptimeNanoseconds,
                 promise: promise
@@ -394,7 +394,7 @@ extension Identify {
                 self.logger.warning("Identify::Failed to ping addr `\(addr)`. A valid peerID is neccessary")
                 return self.el.makeFailedFuture(Errors.timedOut)
             }
-            if let outstandingPing = self.pingCache[peer.bytes] {
+            if let outstandingPing = self.pingCache[peer.id] {
                 // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
                 if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
                     print("We have an outstanding ping thats older than 3 seconds")
@@ -403,11 +403,11 @@ extension Identify {
                     // If the outstanding ping hasn't timed out yet, just return the results of the existing promise
                     return promise.futureResult
                 }
-                self.pingCache.removeValue(forKey: peer.bytes)
+                self.pingCache.removeValue(forKey: peer.id)
             }
             //guard self.pingCache[peer.bytes] == nil else { return application!.eventLoopGroup.next().makeFailedFuture(Errors.timedOut) }
             let promise = self.application!.eventLoopGroup.next().makePromise(of: TimeAmount.self)
-            self.pingCache[peer.bytes] = PendingPing(
+            self.pingCache[peer.id] = PendingPing(
                 peer: "",
                 startTime: DispatchTime.now().uptimeNanoseconds,
                 promise: promise

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -414,18 +414,6 @@ final class LibP2PIdentifyTests: XCTestCase {
         XCTAssertEqual(latency1, latency2)
         XCTAssertEqual(latency2, latency3)
     }
-
-    static var allTests = [
-        ("testIPFSIdentifyPayload", testIPFSIdentifyPayload),
-        ("testIPFSIdentifyPushPayloadJSClient", testIPFSIdentifyPushPayloadJSClient),
-        ("testIDPushRecordDecoding", testIDPushRecordDecoding),
-        ("testLibP2PInternalPingMultiaddr", testLibP2PInternalPingMultiaddr),
-        ("testLibP2PInternalPingPeer", testLibP2PInternalPingPeer),
-        (
-            "testLibP2PInternalPingPeerCascadeMultipleInflightPings",
-            testLibP2PInternalPingPeerCascadeMultipleInflightPings
-        ),
-    ]
 }
 
 struct Fixtures {


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```