### PR TITLE
Replace MPLEX with YAMUX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.0")),
 
         // Test Dependencies
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-mplex.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-yamux.git", .upToNextMinor(from: "0.2.1")),
         .package(url: "https://github.com/swift-libp2p/swift-libp2p-noise.git", .upToNextMinor(from: "0.2.0")),
     ],
     targets: [
@@ -53,7 +53,7 @@ let package = Package(
             dependencies: [
                 "LibP2PIdentify",
                 .product(name: "LibP2PNoise", package: "swift-libp2p-noise"),
-                .product(name: "LibP2PMPLEX", package: "swift-libp2p-mplex"),
+                .product(name: "LibP2PYAMUX", package: "swift-libp2p-yamux"),
             ]
         ),
     ]

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -19,7 +19,7 @@ import Testing
 @testable import LibP2P
 @testable import LibP2PIdentify
 
-@Suite("Libp2p Identify Tests", .serialized)
+@Suite("Libp2p Identify Tests", .serialized, .timeLimit(.minutes(5)))
 struct LibP2PIdentifyTests {
 
     @Test func testIPFSIdentifyPayload() throws {

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -98,6 +98,8 @@ struct LibP2PIdentifyTests {
 
         try application.start()
 
+        defer { application.shutdown() }
+
         /// Ensure our identifiedPeer Events are being fired correctly
         var peerUpdateEvents: Int = 0
         application.events.on(
@@ -254,8 +256,6 @@ struct LibP2PIdentifyTests {
         //application.peers.dumpAll()
 
         sleep(1)
-
-        application.shutdown()
     }
 
     @Test func testLibP2PInternalPingMultiaddr() throws {

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LibP2PMPLEX
 import LibP2PNoise
 import LibP2PYAMUX
 import Testing

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -14,6 +14,7 @@
 
 import LibP2PMPLEX
 import LibP2PNoise
+import LibP2PYAMUX
 import Testing
 
 @testable import LibP2P
@@ -431,6 +432,7 @@ struct LibP2PIdentifyTests {
         try await host.startup()
         try await client.startup()
 
+        // Yamux handles 10_000 requests in ~40 seconds
         for _ in 0..<numberOfRequests {
             /// Fire off an echo request
             let response = try await client.newRequest(
@@ -464,7 +466,7 @@ extension LibP2PIdentifyTests {
     ) throws -> Application {
         let lib = try Application(.testing, peerID: peerID ?? PeerID(.Ed25519))
         lib.security.use(.noise)
-        lib.muxers.use(.mplex)
+        lib.muxers.use(.yamux)
         lib.servers.use(.tcp(host: "127.0.0.1", port: port))
 
         lib.logger.logLevel = logLevel
@@ -492,7 +494,7 @@ extension LibP2PIdentifyTests {
     ) throws -> Application {
         let lib = try Application(.testing, peerID: peerID ?? PeerID(.Ed25519))
         lib.security.use(.noise)
-        lib.muxers.use(.mplex)
+        lib.muxers.use(.yamux)
         lib.servers.use(.tcp(host: "127.0.0.1", port: port))
 
         lib.logger.logLevel = logLevel

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -441,7 +441,7 @@ struct LibP2PIdentifyTests {
         try await client.asyncShutdown()
     }
 
-    @Test(arguments: [10, 100, 1_000])
+    @Test(.timeLimit(.minutes(2)), arguments: [3, 5, 10])
     func testInternalInteropMultipleRequests_Sequentially(_ numberOfRequests: Int) async throws {
         let host = try makeEchoHost(port: 10000)
         let client = try makeClient(port: 10001)

--- a/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
+++ b/Tests/LibP2PIdentifyTests/LibP2PIdentifyTests.swift
@@ -96,6 +96,8 @@ struct LibP2PIdentifyTests {
 
         let application = Application(.testing)
 
+        try application.start()
+
         /// Ensure our identifiedPeer Events are being fired correctly
         var peerUpdateEvents: Int = 0
         application.events.on(


### PR DESCRIPTION
### What
- This PR replaces [MPLEX](https://github.com/swift-libp2p/swift-libp2p-mplex) (which has been deprecated by libp2p) with [YAMUX](https://github.com/swift-libp2p/swift-libp2p-yamux) 
- This dependency is only used within the `LibP2PIdentifyTests` target